### PR TITLE
Use HTTP 1.1 in for NS1 dynamic DNS HTTPS monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## v0.0.3 - 2022-??-?? - Support the root
+## v0.0.3 - 2023-??-?? - Support the root
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
   octodns>=0.9.16.
+* Use HTTP 1.1 in for NS1 dynamic DNS HTTPS monitors
 
 ## v0.0.2 - 2022-02-02 - pycountry-convert install_requires
 
@@ -10,7 +11,7 @@
 
 ## v0.0.1 - 2022-01-03 - Moving
 
-#### Nothworthy Changes
+#### Noteworthy Changes
 
 * Initial extraction of Ns1Provider from octoDNS core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
   octodns>=0.9.16.
-* Use HTTP 1.1 in for NS1 dynamic DNS HTTPS monitors
+* Configurable http version for dynamic HTTPS monitors, to enable HTTP/1.1 support
 
 ## v0.0.2 - 2022-02-02 - pycountry-convert install_requires
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See https://github.com/octodns/octodns/blob/master/docs/dynamic_records.md#healt
 | connect_timeout | Timeout (in seconds) before we give up trying to connect | 2 |
 | response_timeout | Timeout (in seconds) after connecting to wait for output | 10 |
 | rapid_recheck | Enable or disable a second, automatic verification test before changing the status of a host. Enabling this option can help prevent false positives. | False |
+| http_version | Specify HTTP version to use when HTTP health-checking  a host. One of <ol><li>`HTTP/1.0`</li><li>`HTTP/1.1`</li><ol> | `HTTP/1.0` |
 
 ```yaml
 ---
@@ -99,6 +100,7 @@ See https://github.com/octodns/octodns/blob/master/docs/dynamic_records.md#healt
         connect_timeout: 2
         response_timeout: 10
         rapid_recheck: True
+        http_version: HTTP/1.1
 ```
 
 ### Development


### PR DESCRIPTION
== Problem ==

Currently NS1 monitors generated by octodns-ns1 use HTTP 1.0 (smuggled over a TCP connection). This does not work when pointing to Azure Storage accounts. This ticket is to create a PR to change these monitors to use HTTP 1.1

== Example ==

NS1 doesn't actually create HTTP monitors, instead prefering to create TCP monitors and manually constructing HTTP messages on top. We can emulate sending a monitor ping to an Azure storage blob using `ncat`:

```
$ printf 'GET /admin HTTP/1.0\r\nHost: <storageaccountnamehere>.z5.web.core.windows.net\r\nUser-agent: NS1\r\n\r\n' | ncat --ssl <storageaccountnamehere>.z5.web.core.windows.net 443
HTTP/1.1 505 The HTTP version specified is not supported for this operation by the server.
Content-Length: 369
Content-Type: text/html
Server: Windows-Azure-Web/1.0 Microsoft-HTTPAPI/2.0
x-ms-error-code: UnsupportedHttpVersion
x-ms-request-id: 400f2f1b-101e-0013-1eb5-26566a000000
x-ms-version: 2018-03-28
Date: Thu, 12 Jan 2023 18:43:30 GMT
Connection: close

<!DOCTYPE html><html><head><title>UnsupportedHttpVersion</title></head><body><h1>The HTTP version specified is not supported for this operation by the server.</h1><p><ul><li>HttpStatusCode: 505</li><li>ErrorCode: UnsupportedHttpVersion</li><li>RequestId : 400f2f1b-101e-0013-1eb5-26566a000000</li><li>TimeStamp : 2023-01-12T18:43:30.9213214Z</li></ul></p></body></html>
```

This returns a 505 because the storage account doesn't accept HTTP 1.0

We can easily fix this by using HTTP 1.1:

```
$ printf 'GET /admin HTTP/1.1\r\nHost: <storageaccountnamehere>.z5.web.core.windows.net\r\nUser-agent: NS1\r\n\r\n' | ncat --ssl <storageaccountnamehere>.z5.web.core.windows.net 443
HTTP/1.1 200 OK
Content-Length: 5
Content-Type: application/octet-stream
Content-MD5: +dncK6slcrqVz9Z7WWptGg==
Last-Modified: Tue, 10 Jan 2023 23:42:26 GMT
Accept-Ranges: bytes
ETag: "0x8DAF3645475F653"
Server: Windows-Azure-Web/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: d2b0f662-601e-007b-24b6-2630fa000000
x-ms-version: 2018-03-28
Date: Thu, 12 Jan 2023 18:45:47 GMT

GOOD
```

I've also tested this using actual NS1 monitors (you can't see the actual HTTP response from them, they just show "failed" becasue "200 OK" is not in the response).

== Will this change break anything? ==

This change requires any existing endpoints to understand HTTP 1.1, instead of the current requirement to only understand HTTP 1.0.

Here's why I think that's ok:

- HTTP 1.1 was introduced in 1999, so existing endpoints have had 22 years to learn about HTTP 1.1.
- HTTP 1.1 *requires* the `Host` header, but when constructing monitors, octoDNS always provides one.
- It's difficult to tell how much of the internet still uses HTTP 1.0, but most of the links I've found were from 10 years ago and it people said usage was declining then.

In any event, octodns generated monitors NOT supporting HTTP 1.1 is breaking things for us, hence this PR. If there are better ways to handle this, happy to change this approach.

== Testing ==

In addition to the unit tests, I also made a test dynamic record on NS1 and verified the created monitor successfully HTTP GETs the /admin path from the Azure Storage Account